### PR TITLE
Changed Strings.java to reflect different name and allowed to be subclassed

### DIFF
--- a/src/edu/first/util/StringUtil.java
+++ b/src/edu/first/util/StringUtil.java
@@ -9,9 +9,9 @@ import edu.first.util.list.ArrayList;
  * @since May 14 13
  * @author Joel Gallant
  */
-public final class Strings {
+public class StringUtil {
 
-    // cannot be subclassed or instantiated
+    // cannot be instantiated
     private Strings() throws IllegalAccessException {
         throw new IllegalAccessException();
     }


### PR DESCRIPTION
Changed name to StringUtil and the class is not final anymore. Allowed to be sub-classed. Fixed documentation to reflect this change.
